### PR TITLE
Update url to Raphael library:

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title>flowchart.js · Playground</title>
-        <script src="http://raphaeljs.com/raphael.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.2/raphael-min.js"></script>
         <script src="../bin/flowchart-latest.js"></script>
         <script>
 


### PR DESCRIPTION
- Use protocol relative url
- Use cdnjs hosted file

Note: the caveat is that using this locally will result in an error since the http/https is not handled by the file: protocol, unless you run a simple server. In Mac, I run Python's SimpleHTTPServer, but there are many options, including node, mamp, etc.. so it seems like a non-issue.
