### PR TITLE
Added node id to objects

### DIFF
--- a/src/flowchart.symbol.condition.js
+++ b/src/flowchart.symbol.condition.js
@@ -62,6 +62,7 @@ function Condition(chart, options) {
   });
   if (options.link) { symbol.attr('href', options.link); }
   if (options.target) { symbol.attr('target', options.target); }
+  if (options.key) { symbol.node.id = options.key; }
 
   this.text.attr({
     y: symbol.getBBox().height/2

--- a/src/flowchart.symbol.inputoutput.js
+++ b/src/flowchart.symbol.inputoutput.js
@@ -29,6 +29,7 @@ function InputOutput(chart, options) {
   });
   if (options.link) { symbol.attr('href', options.link); }
   if (options.target) { symbol.attr('target', options.target); }
+  if (options.key) { symbol.node.id = options.key; }
 
   this.text.attr({
     y: symbol.getBBox().height/2

--- a/src/flowchart.symbol.js
+++ b/src/flowchart.symbol.js
@@ -7,6 +7,8 @@ function Symbol(chart, options, symbol) {
   this.next_direction = options.next && options['direction_next'] ? options['direction_next'] : undefined;
 
   this.text = this.chart.paper.text(0, 0, options.text);
+  //Raphael does not support the svg group tag so setting the text node id to the symbol node id plus t
+  if (options.key) { this.text.node.id = options.key + 't'; }
   this.text.attr({
     'text-anchor': 'start',
     'font-size': (this.chart.options.symbols[this.symbolType]['font-size'] || this.chart.options['font-size']),
@@ -52,6 +54,7 @@ function Symbol(chart, options, symbol) {
     });
     if (options.link) { symbol.attr('href', options.link); }
     if (options.target) { symbol.attr('target', options.target); }
+    if (options.key) { symbol.node.id = options.key; }
 
     this.group.push(symbol);
     symbol.insertBefore(this.text);


### PR DESCRIPTION
Set node id for symbols and text.  Append a t to the text since Raphael does not support SVG groups.

I can then use jquery to manipulate the chart.

//change fill color to green for completed steps
$('#st').attr('fill', 'green')

//alert on both the symbol and the text
 $('#st*').click( function(){
        alert('info here');
    });
