### PR TITLE
Remove protocol from external script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,10 +161,10 @@ c2(no)->op2->e</div>
       </div>
     </footer>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 
     <!-- Needed for the text editor -->
-    <script src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="//d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
 
     <script src="underscore-min.js"></script>
     <script src="raphael-min.js"></script>


### PR DESCRIPTION
This is only for the Github Pages demo.

Allows external resources to be loaded if you're on `http` and `https`.

# Screenshot

![image](https://cloud.githubusercontent.com/assets/172217/6095398/7497faf8-af10-11e4-9668-400ff832bb2a.png)

*Note blocked JS in the console.*