### PR TITLE
Fix url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [example](https://github.com/adrai/flowchart.js/blob/master/example/index.html)
 
 #Requirements
-You will need [Raphaël](http://raphaeljs.com/)
+You will need [Raphaël](http://www.raphaeljs.com/)
 
 #Usage
 


### PR DESCRIPTION
Small typo fix in the README, currently when clicking on the link it gets an unreachable domain. 