### PR TITLE
Allow going to same symbol

### DIFF
--- a/src/flowchart.symbol.js
+++ b/src/flowchart.symbol.js
@@ -239,7 +239,7 @@ Symbol.prototype.drawLineTo = function(symbol, text, origin) {
   var isOnSameColumn = x === symbolX,
       isOnSameLine = y === symbolY,
       isUnder = y < symbolY,
-      isUpper = y > symbolY,
+      isUpper = y > symbolY || this === symbol,
       isLeft = x > symbolX,
       isRight = x < symbolX;
 


### PR DESCRIPTION
```
st=>start
end=>end
op=>operation: Operation
cond=>condition: Condition

st->cond
cond(yes)->op->op
cond(no)->cond
```

before:

<img width="144" alt="screenshot_2016-05-26_21 45 31" src="https://cloud.githubusercontent.com/assets/7397316/15574936/2f47c668-238b-11e6-992c-667504eab33e.png">


after: 
<img width="191" alt="screenshot_2016-05-26_21 41 37" src="https://cloud.githubusercontent.com/assets/7397316/15574854/aaa0d71a-238a-11e6-819e-3b546f5ba157.png">