### PR TITLE
Add maxWidth to the example configuration options

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -29,6 +29,7 @@
                       // 'x': 30,
                       // 'y': 50,
                       'line-width': 3,
+                      'maxWidth': 3,//ensures the flowcharts fits within a certian width
                       'line-length': 50,
                       'text-margin': 10,
                       'font-size': 14,


### PR DESCRIPTION
I spent ages trying to debug your code so that I could control the line length to the right that seems to double after each condition whether there is nesting or not.  After about 20 minutes of no luck (code formatting? comments? lol) I found maxWidth and it solved my problem without having to go further.
