### PR TITLE
Fix disruptive space char when parsing

### DIFF
--- a/src/flowchart.parse.js
+++ b/src/flowchart.parse.js
@@ -149,7 +149,7 @@ function parse(input) {
   }
 
   while (lines.length > 0) {
-    var line = lines.splice(0, 1)[0];
+    var line = lines.splice(0, 1)[0].trim();
 
     if (line.indexOf('=>') >= 0) {
       // definition


### PR DESCRIPTION
Reproduction:

Open locally (here in Firefox):
index.html
```
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="utf-8">
    <title>flowchart.js · Playground</title>
    <style type="text/css">
        .end-element { background-color : #FFCCFF; }
    </style>
    <script src="http://cdnjs.cloudflare.com/ajax/libs/raphael/2.2.0/raphael-min.js"></script>
    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowchart/1.6.5/flowchart.js"></script>

    <script>
        $(document).ready(function() {
            $.ajax({
                url : "test.txt",
                //contentType : "text/plain",
				//mimeType: 'text/plain; charset=x-user-defined',
				dataType : "text",
                success : function(data) {
					console.log("PARSE1!!!");
                    var chart1 = flowchart.parse(data);
                    chart1.drawSVG('canvas');
					
					console.log("PARSE2!!!");
					var chart2 = flowchart.parse(`st=>start: Start:>http://www.google.com
e=>end:>http://www.google.com
op1=>operation: My Ooooperation
sub1=>subroutine: My Subroutine
cond=>condition: Yes
or No?:>http://www.google.com
io=>inputoutput: catch something...

st->op1(right)->cond
cond(yes)->io->e
cond(no)->sub1(right)->op1`);
                    chart2.drawSVG('canvas');
                }
            });
        });
    </script>
</head>
<body>
<div id="canvas"></div>
</body>
</html>
```
test.txt
```
st=>start: Start:>http://www.google.com
e=>end:>http://www.google.com
op1=>operation: My Ooooperation
sub1=>subroutine: My Subroutine
cond=>condition: Yes
or No?:>http://www.google.com
io=>inputoutput: catch something...

st->op1(right)->cond
cond(yes)->io->e
cond(no)->sub1(right)->op1
```

flowSymbols will be (notice the space behind `cond `)
```
Array [ "st", "op1(right)", "cond " ]
// ergo when i=2
var flowSymb = flowSymbols[i], realSymb = getSymbol(flowSymb)
// realSymb will be undefined
```

Result:
![Result](https://i.imgur.com/mt2HiRH.png)

The second chart parsed within the `index.html` is displayed correctly, whereas the one parsed from file `test.txt` is not.