### PR TITLE
Use markdown syntax for headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 [![JS.ORG](https://img.shields.io/badge/js.org-flowchart-ffb400.svg?style=flat-square)](http://js.org)
 
-#Example
+# flowchart.js
+
+## Example
 
 [example](https://github.com/adrai/flowchart.js/blob/master/example/index.html)
 
-#Requirements
+## Requirements
 You will need [Raphaël](http://www.raphaeljs.com/)
 
-#CDN
+## CDN
 flowchart.js is on [CDNJS](https://cdnjs.com/libraries/flowchart), feel free to use it
 
-#Usage
+## Usage
 
 On your page you need to include raphael like so:
 
@@ -85,18 +87,18 @@ and then
 </script>
 ```
 
-#Advice
+## Advice
 Symbols that should possibly not be used in the text: '=>' and '->' and ':>' and '|'
 
-#Contributors
+## Contributors
 
 via [GitHub](https://github.com/adrai/flowchart.js/graphs/contributors)
 
-#Thanks
+## Thanks
 
 Many thanks to [js-sequence-diagrams](http://bramp.github.io/js-sequence-diagrams/) which greatly inspired this project, and forms the basis for the syntax.
 
-#Licence
+## Licence
 
 Copyright (c) 2017 Adriano Raiano
 


### PR DESCRIPTION
For easier readability, I made sure the spacing is correct between '#' and the header title in order to be correctly displayed in markdown.