### PR TITLE
add line style flow support (#113)

### DIFF
--- a/src/flowchart.parse.js
+++ b/src/flowchart.parse.js
@@ -115,13 +115,22 @@ function parse(input) {
   for (var l = 1, len = lines.length; l < len;) {
     var currentLine = lines[l];
 
-    if (currentLine.indexOf('->') < 0 && currentLine.indexOf('=>') < 0) {
+    if (currentLine.indexOf('->') < 0 && currentLine.indexOf('=>') < 0 && currentLine.indexOf('@>') < 0) {
       lines[l - 1] += '\n' + currentLine;
       lines.splice(l, 1);
       len--;
     } else {
       l++;
     }
+  }
+
+  function getStyle(s){
+    var startIndex = s.indexOf('(') + 1;
+    var endIndex = s.indexOf(')');
+    if (startIndex >= 0 && endIndex >= 0) {
+      return s.substring(startIndex,endIndex);
+    }
+    return '{}';
   }
 
   function getSymbol(s) {
@@ -160,7 +169,8 @@ function parse(input) {
         text: null,
         link: null,
         target: null,
-        flowstate: null
+        flowstate: null,
+        lineStyle: {}
       };
 
       var sub;
@@ -233,6 +243,19 @@ function parse(input) {
           realSymb[next] = getSymbol(nextSymb);
           realSymb['direction_' + next] = direction;
           direction = null;
+        }
+      }
+    } else if (line.indexOf('@>') >= 0) {
+
+      // line style
+      var lineStyleSymbols = line.split('@>');
+      for (var i = 0, lenS = lineStyleSymbols.length; i < lenS; i++) {
+
+        if ((i+1) != lenS){
+          var curSymb = getSymbol(lineStyleSymbols[i]);
+          var nextSymb = getSymbol(lineStyleSymbols[i+1])
+
+          curSymb['lineStyle'][nextSymb.key] = JSON.parse(getStyle(lineStyleSymbols[i+1]));
         }
       }
     }

--- a/src/flowchart.symbol.js
+++ b/src/flowchart.symbol.js
@@ -9,6 +9,8 @@ function Symbol(chart, options, symbol) {
   this.connectedTo = [];
   this.symbolType = options.symbolType;
   this.flowstate = (options.flowstate || 'future');
+  this.lineStyle = (options.lineStyle || {});
+  this.key = (options.key || '');
 
   this.next_direction = options.next && options['direction_next'] ? options['direction_next'] : undefined;
 
@@ -366,6 +368,11 @@ Symbol.prototype.drawLineTo = function(symbol, text, origin) {
     this.leftStart = true;
     symbol.topEnd = true;
     maxX = left.x;
+  }
+
+  //update line style
+  if (this.lineStyle[symbol.key] && line){
+      line.attr( this.lineStyle[symbol.key]);
   }
 
   if (line) {


### PR DESCRIPTION
According to #113, implementation of flow for line style with addition of a new `@>` separator

Usage example 
```
st@>op1({"stroke":"Red"})@>cond1({"stroke":"Red","stroke-width":6,"arrow-end":"classic-wide-long"})@>cond6({"stroke":"Red"})@>op4({"stroke":"Red"})@>end({"stroke":"Red"})
```