### PR TITLE
add parameter to disable vertical alignment of condition symbol (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and then
                                 'e=>end:>http://www.google.com\n' +
                                 'op1=>operation: My Operation\n' +
                                 'sub1=>subroutine: My Subroutine\n' +
-                                'cond=>condition: Yes \n' +
+                                'cond=>condition: Yes \n' + // use cond(align-next=no) to disable vertical align of symbols below
                                 'or No?\n:>http://www.google.com' +
                                 'io=>inputoutput|request: catch something...\n' +
                                 '' +

--- a/src/flowchart.parse.js
+++ b/src/flowchart.parse.js
@@ -155,13 +155,26 @@ function parse(input) {
       // definition
       var parts = line.split('=>');
       var symbol = {
-        key: parts[0],
+        key: parts[0].replace(/\(.*\)/, ''),
         symbolType: parts[1],
         text: null,
         link: null,
         target: null,
-        flowstate: null
+        flowstate: null,
+        params: {}
       };
+
+      //parse parameters
+      var params = parts[0].match(/\((.*)\)/);
+      if (params && params.length > 1){
+        var entries = params[1].split(',');
+        for(var i = 0; i < entries.length; i++) {
+          var entry = entries[0].split('=');
+          if (entry.length == 2){
+            symbol.params[entry[0]] = entry[1];
+          }
+        }
+      }
 
       var sub;
 

--- a/src/flowchart.symbol.condition.js
+++ b/src/flowchart.symbol.condition.js
@@ -9,6 +9,7 @@ function Condition(chart, options) {
   this.textMargin = this.getAttr('text-margin');
   this.yes_direction = 'bottom';
   this.no_direction = 'right';
+  this.params = options.params;
   if (options.yes && options.direction_yes && options.no && !options.direction_no) {
     if (options.direction_yes === 'right') {
       this.no_direction = 'bottom';
@@ -120,10 +121,12 @@ Condition.prototype.render = function() {
         for (var i = 0, len = self.chart.symbols.length; i < len; i++) {
           symb = self.chart.symbols[i];
 
-          var diff = Math.abs(symb.getCenter().x - self.right_symbol.getCenter().x);
-          if (symb.getCenter().y > self.right_symbol.getCenter().y && diff <= self.right_symbol.width/2) {
-            hasSymbolUnder = true;
-            break;
+          if (!self.params['align-next'] || self.params['align-next'] !== 'no') { 
+            var diff = Math.abs(symb.getCenter().x - self.right_symbol.getCenter().x);
+            if (symb.getCenter().y > self.right_symbol.getCenter().y && diff <= self.right_symbol.width/2) {
+              hasSymbolUnder = true;
+              break;
+            }
           }
         }
 


### PR DESCRIPTION
According to #115, add parameters to symbol declaration with enclosed parenthesis and entries separated by `=` such as 
```
cond1(param1=value1)=>condition: some condition
```
Also add parameter `align-next` used in condition symbol rendering to disable vertical alignment if needed

Example 
```
cond1(align-next=no)=>condition: some condition
cond6(align-next=no)=>condition: another condition
```
If the parameter `align-next` is not specified, or if it doesn't hold `no` value, the default behavior is used
