### PR TITLE
Make symbol and params attribute always available for all kinds of Symbols

### DIFF
--- a/src/flowchart.symbol.condition.js
+++ b/src/flowchart.symbol.condition.js
@@ -11,7 +11,6 @@ function Condition(chart, options) {
   this.textMargin = this.getAttr('text-margin');
   this.yes_direction = options.direction_yes;
   this.no_direction = options.direction_no;
-  this.params = options.params;
   if (!this.no_direction && this.yes_direction === 'right') {
     this.no_direction = 'bottom';
   } else if (!this.yes_direction && this.no_direction === 'bottom') {
@@ -63,6 +62,7 @@ function Condition(chart, options) {
 
   this.group.push(symbol);
   symbol.insertBefore(this.text);
+  this.symbol = symbol
 
   this.initialize();
 }

--- a/src/flowchart.symbol.inputoutput.js
+++ b/src/flowchart.symbol.inputoutput.js
@@ -44,6 +44,7 @@ function InputOutput(chart, options) {
 
   this.group.push(symbol);
   symbol.insertBefore(this.text);
+  this.symbol = symbol
 
   this.initialize();
 }

--- a/src/flowchart.symbol.js
+++ b/src/flowchart.symbol.js
@@ -15,6 +15,7 @@ function Symbol(chart, options, symbol) {
   this.rightLines = [];
   this.topLines = [];
   this.bottomLines = [];
+  this.params = options.params;
 
   this.next_direction = options.next && options['direction_next'] ? options['direction_next'] : undefined;
 


### PR DESCRIPTION
The behavior of all kinds of Symbols will be more consistent, make it easier to extend the library.