### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Connection syntax is as follows:
 Items in `[]` are optional.
 
 ### Directions
-The following directions are available and define the direction the connection will leave the node from. If there are more than one specifiers, it is always the last. All nodes have a default direction making this an optional specification. `<direction>` will be used to indicate that one of the below should be used in its place.
+The following directions are available and define the direction the connection will leave the node from. If there are more than one specifiers, it is always the last. All nodes have a default direction making this an optional specification. `<direction>` will be used to indicate that one of the following should be used in its place.
 
 * left
 * right
@@ -264,7 +264,7 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
+The preceding copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR


### PR DESCRIPTION
 - 'the above [notice]' violates adjective order, so let's use 'preceding' to avoid it.
 - 'the below' is also a bit of a gaffe when there's no object (preceding it) to modify, so let's avoid that too.
